### PR TITLE
Charts no longer plotted inline on notebooks

### DIFF
--- a/How to get started in data science .ipynb
+++ b/How to get started in data science .ipynb
@@ -834,6 +834,7 @@
     }
    ],
    "source": [
+    "%matplotlib inline\n",
     "data['Age'].hist()"
    ]
   },


### PR DESCRIPTION
Nice meetup. To share it, I made it work like a charm with a single command on docker but the charts were not being plot. Newer versions of jupyter/IPython dropped the inline configuration from the command line. So the notebook itself must now include the magic command "%matplotlib inline".